### PR TITLE
Handle empty `choices` field in response chunks

### DIFF
--- a/src/threads.py
+++ b/src/threads.py
@@ -88,7 +88,12 @@ class StreamingThread(QtCore.QThread):
             for chunk in response:
                 if not self.running:  # Stop consuming stream if interrupted
                     return
-                message_chunk = chunk.choices[0].delta.content or ""
+
+                if not chunk.choices:
+                    message_chunk = ""
+                else:
+                    message_chunk = chunk.choices[0].delta.content or ""
+
                 response_buffer += message_chunk
                 self.update_response.emit({"response":response_buffer})
 


### PR DESCRIPTION
Hi, and thank you for your work!

When using the plugin, I noticed that if the `choices` field of the first response chunk is empty, the plugin crashes as it is trying to access the first value of the list. This PR should fix it.

Thanks!