### PR TITLE
Added default path for claude-cli on macos

### DIFF
--- a/src/services/llm_providers/anthropic_claude_cli_provider.py
+++ b/src/services/llm_providers/anthropic_claude_cli_provider.py
@@ -197,6 +197,7 @@ class AnthropicClaudeCliProvider(BaseLLMProvider):
             common_paths = [
                 '/usr/local/bin/claude',
                 '/opt/homebrew/bin/claude',  # Apple Silicon Homebrew
+                os.path.expanduser('~/.local/bin/claude'),
                 os.path.expanduser('~/.npm-global/bin/claude'),
                 os.path.expanduser('~/Library/npm/bin/claude'),
             ]


### PR DESCRIPTION
macos branch missed default path for claude-code installation from the official site
so if i install CC such way, then BinAssist unable to find it